### PR TITLE
refactor test codes, fix minor things

### DIFF
--- a/dist/dist_test.go
+++ b/dist/dist_test.go
@@ -52,22 +52,9 @@ func TestCheckAPIVersion(t *testing.T) {
 
 	inputURL := "https://" + indexServer + "/v2/" + reqPath
 
-	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "GET", nil)
+	res, err := regAuthCtx.GetResponse(inputURL, "GET", nil, []int{http.StatusOK})
 	if err != nil {
-		t.Fatalf("failed to send request with token to %s: %v", inputURL, err)
-	}
-
-	switch res.StatusCode {
-	case http.StatusCreated:
-		t.Fatalf("got an unexpected reply: 201 Created")
-	case http.StatusUnauthorized:
-		t.Fatalf("got an unexpected reply: 401 Unauthorized")
-	case http.StatusNotFound:
-		t.Fatalf("got an unexpected reply: 404 Not Found")
-	case http.StatusOK:
-		break
-	default:
-		t.Fatalf("statusCode = %v, request URL = %v", res.StatusCode, inputURL)
+		t.Fatalf("got an unexpected reply: %v", err)
 	}
 
 	if vers := res.Header.Get(distp.DistAPIVersionKey); vers != distp.DistAPIVersionValue {
@@ -91,22 +78,8 @@ func TestPullManifest(t *testing.T) {
 
 	inputURL := "https://" + indexServer + "/v2/" + reqPath
 
-	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "GET", nil)
-	if err != nil {
-		t.Fatalf("failed to send request with token to %s: %v", inputURL, err)
-	}
-
-	switch res.StatusCode {
-	case http.StatusOK:
-		return
-	case http.StatusCreated:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusNotFound:
-		t.Fatalf("got an unexpected reply: %v", res.StatusCode)
-	default:
-		t.Fatalf("statusCode = %v, request URL = %v", res.StatusCode, inputURL)
+	if _, err := regAuthCtx.GetResponse(inputURL, "GET", nil, []int{http.StatusOK}); err != nil {
+		t.Fatalf("got an unexpected reply: %v", err)
 	}
 }
 
@@ -126,21 +99,7 @@ func TestPushManifest(t *testing.T) {
 
 	inputURL := "https://" + indexServer + "/v2/" + reqPath
 
-	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "PUT", nil)
-	if err != nil {
-		t.Fatalf("failed to send request with token to %s: %v", inputURL, err)
-	}
-
-	switch res.StatusCode {
-	case http.StatusOK:
-		return
-	case http.StatusCreated:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusNotFound:
-		t.Fatalf("got an unexpected reply: %v", res.StatusCode)
-	default:
-		t.Fatalf("statusCode = %v, request URL = %v", res.StatusCode, inputURL)
+	if _, err := regAuthCtx.GetResponse(inputURL, "PUT", nil, []int{http.StatusOK}); err != nil {
+		t.Fatalf("got an unexpected reply: %v", err)
 	}
 }

--- a/dist/dist_test.go
+++ b/dist/dist_test.go
@@ -30,20 +30,23 @@ var (
 
 	testImageName string = "busybox"
 	testRefName   string = "latest"
+	regURL        string
 )
 
 func init() {
 	homeDir = os.Getenv("HOME")
+
+	regURL = regAuthCtx.RegURL
 }
 
 func TestCheckAPIVersion(t *testing.T) {
 	reqPath := ""
 
-	indexServer := auth.GetIndexName(auth.DefaultIndexURLAuth)
-
-	regAuthCtx = auth.NewRegAuthContext()
+	regAuthCtx := auth.NewRegAuthContext()
 	regAuthCtx.Scope.RemoteName = reqPath
 	regAuthCtx.Scope.Actions = "pull"
+
+	indexServer := auth.GetIndexServer(regURL)
 
 	if err := regAuthCtx.PrepareAuth(indexServer); err != nil {
 		t.Fatalf("failed to prepare auth to %s for %s: %v", indexServer, reqPath, err)
@@ -62,12 +65,12 @@ func TestCheckAPIVersion(t *testing.T) {
 }
 
 func TestPullManifest(t *testing.T) {
-	indexServer := auth.GetIndexName(auth.DefaultIndexURLAuth)
+	indexServer := auth.GetIndexServer(regURL)
 
 	remoteName := filepath.Join(auth.DefaultRepoPrefix, testImageName)
 	reqPath := filepath.Join(remoteName, "manifests", testRefName)
 
-	regAuthCtx = auth.NewRegAuthContext()
+	regAuthCtx := auth.NewRegAuthContext()
 	regAuthCtx.Scope.RemoteName = remoteName
 	regAuthCtx.Scope.Actions = "pull"
 
@@ -83,12 +86,12 @@ func TestPullManifest(t *testing.T) {
 }
 
 func TestPushManifest(t *testing.T) {
-	indexServer := auth.GetIndexName(auth.DefaultIndexURLAuth)
+	indexServer := auth.GetIndexServer(regURL)
 
 	remoteName := filepath.Join(auth.DefaultRepoPrefix, testImageName)
 	reqPath := filepath.Join(remoteName, "manifests", testRefName)
 
-	regAuthCtx = auth.NewRegAuthContext()
+	regAuthCtx := auth.NewRegAuthContext()
 	regAuthCtx.Scope.RemoteName = remoteName
 	regAuthCtx.Scope.Actions = "push"
 

--- a/dist/dist_test.go
+++ b/dist/dist_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kinvolk/ocicert/pkg/auth"
 	distp "github.com/kinvolk/ocicert/pkg/distp"
-	"github.com/kinvolk/ocicert/pkg/image"
 )
 
 var (
@@ -40,7 +39,7 @@ func init() {
 func TestCheckAPIVersion(t *testing.T) {
 	reqPath := ""
 
-	indexServer := image.GetIndexName(image.DefaultIndexURLAuth)
+	indexServer := auth.GetIndexName(auth.DefaultIndexURLAuth)
 
 	regAuthCtx = auth.NewRegAuthContext()
 	regAuthCtx.Scope.RemoteName = reqPath
@@ -63,9 +62,9 @@ func TestCheckAPIVersion(t *testing.T) {
 }
 
 func TestPullManifest(t *testing.T) {
-	indexServer := image.GetIndexName(image.DefaultIndexURLAuth)
+	indexServer := auth.GetIndexName(auth.DefaultIndexURLAuth)
 
-	remoteName := filepath.Join(image.DefaultRepoPrefix, testImageName)
+	remoteName := filepath.Join(auth.DefaultRepoPrefix, testImageName)
 	reqPath := filepath.Join(remoteName, "manifests", testRefName)
 
 	regAuthCtx = auth.NewRegAuthContext()
@@ -84,9 +83,9 @@ func TestPullManifest(t *testing.T) {
 }
 
 func TestPushManifest(t *testing.T) {
-	indexServer := image.GetIndexName(image.DefaultIndexURLAuth)
+	indexServer := auth.GetIndexName(auth.DefaultIndexURLAuth)
 
-	remoteName := filepath.Join(image.DefaultRepoPrefix, testImageName)
+	remoteName := filepath.Join(auth.DefaultRepoPrefix, testImageName)
 	reqPath := filepath.Join(remoteName, "manifests", testRefName)
 
 	regAuthCtx = auth.NewRegAuthContext()

--- a/dist/dist_test.go
+++ b/dist/dist_test.go
@@ -21,12 +21,16 @@ import (
 	"testing"
 
 	"github.com/kinvolk/ocicert/pkg/auth"
+	distp "github.com/kinvolk/ocicert/pkg/distp"
 	"github.com/kinvolk/ocicert/pkg/image"
 )
 
 var (
 	homeDir    string
 	regAuthCtx auth.RegAuthContext
+
+	testImageName string = "busybox"
+	testRefName   string = "latest"
 )
 
 func init() {
@@ -65,16 +69,17 @@ func TestCheckAPIVersion(t *testing.T) {
 	default:
 		t.Fatalf("statusCode = %v, request URL = %v", res.StatusCode, inputURL)
 	}
+
+	if vers := res.Header.Get(distp.DistAPIVersionKey); vers != distp.DistAPIVersionValue {
+		t.Fatalf("got an unexpected API version %v", vers)
+	}
 }
 
 func TestPullManifest(t *testing.T) {
-	imageName := "busybox"
-	refName := "latest"
-
 	indexServer := image.GetIndexName(image.DefaultIndexURLAuth)
 
-	remoteName := filepath.Join(image.DefaultRepoPrefix, imageName)
-	reqPath := filepath.Join(remoteName, "manifests", refName)
+	remoteName := filepath.Join(image.DefaultRepoPrefix, testImageName)
+	reqPath := filepath.Join(remoteName, "manifests", testRefName)
 
 	regAuthCtx = auth.NewRegAuthContext()
 	regAuthCtx.Scope.RemoteName = remoteName
@@ -106,13 +111,10 @@ func TestPullManifest(t *testing.T) {
 }
 
 func TestPushManifest(t *testing.T) {
-	imageName := "busybox"
-	refName := "latest"
-
 	indexServer := image.GetIndexName(image.DefaultIndexURLAuth)
 
-	remoteName := filepath.Join(image.DefaultRepoPrefix, imageName)
-	reqPath := filepath.Join(remoteName, "manifests", refName)
+	remoteName := filepath.Join(image.DefaultRepoPrefix, testImageName)
+	reqPath := filepath.Join(remoteName, "manifests", testRefName)
 
 	regAuthCtx = auth.NewRegAuthContext()
 	regAuthCtx.Scope.RemoteName = remoteName

--- a/dist/dist_test.go
+++ b/dist/dist_test.go
@@ -48,7 +48,7 @@ func TestCheckAPIVersion(t *testing.T) {
 
 	inputURL := "https://" + indexServer + "/v2/" + reqPath
 
-	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "GET")
+	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "GET", nil)
 	if err != nil {
 		t.Fatalf("failed to send request with token to %s: %v", inputURL, err)
 	}
@@ -86,7 +86,7 @@ func TestPullManifest(t *testing.T) {
 
 	inputURL := "https://" + indexServer + "/v2/" + reqPath
 
-	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "GET")
+	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "GET", nil)
 	if err != nil {
 		t.Fatalf("failed to send request with token to %s: %v", inputURL, err)
 	}
@@ -124,7 +124,7 @@ func TestPushManifest(t *testing.T) {
 
 	inputURL := "https://" + indexServer + "/v2/" + reqPath
 
-	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "PUT")
+	_, res, err := regAuthCtx.SendRequestWithToken(inputURL, "PUT", nil)
 	if err != nil {
 		t.Fatalf("failed to send request with token to %s: %v", inputURL, err)
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -32,6 +32,10 @@ import (
 var (
 	defaultScopeAccess        = "pull"
 	defaultRegURL      string = "docker.io/busybox:latest"
+
+	DefaultIndexURLPlain = "registry-1.docker.io"
+	DefaultIndexURLAuth  = "index.docker.io"
+	DefaultRepoPrefix    = "library/"
 )
 
 type AuthScope struct {
@@ -258,4 +262,24 @@ func parseScope(inputScope string) AuthScope {
 	}
 
 	return outScope
+}
+
+// GetIndexName returns the index server from a registry URL.
+func GetIndexName(regURL string) string {
+	index, _ := SplitReposName(regURL)
+	return index
+}
+
+// SplitReposName breaks a repo name into an index name and remote name.
+func SplitReposName(name string) (indexName, remoteName string) {
+	i := strings.IndexRune(name, '/')
+	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
+		indexName, remoteName = DefaultIndexURLPlain, name
+	} else {
+		indexName, remoteName = name[:i], name[i+1:]
+	}
+	if indexName == DefaultIndexURLPlain && !strings.ContainsRune(remoteName, '/') {
+		remoteName = DefaultRepoPrefix + remoteName
+	}
+	return
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -30,12 +30,13 @@ import (
 )
 
 var (
-	defaultScopeAccess        = "pull"
-	defaultRegURL      string = "docker.io/busybox:latest"
+	defaultScopeAccess string = "pull"
+	DefaultRepoPrefix  string = "library/"
 
-	DefaultIndexURLPlain = "registry-1.docker.io"
-	DefaultIndexURLAuth  = "index.docker.io"
-	DefaultRepoPrefix    = "library/"
+	defaultRegURL        string = "docker.io/busybox:latest"
+	DefaultIndexURLPlain string = "registry-1.docker.io"
+	dockerHostname       string = "docker.io"
+	dockerV1Hostname     string = "index.docker.io"
 )
 
 type AuthScope struct {
@@ -282,4 +283,15 @@ func SplitReposName(name string) (indexName, remoteName string) {
 		remoteName = DefaultRepoPrefix + remoteName
 	}
 	return
+}
+
+func GetIndexServer(inputURL string) string {
+	indexServer := GetIndexName(inputURL)
+	// we should use v1 hostname index.docker.io, because docker.io disabled
+	// numerous endpoints.
+	if indexServer == dockerHostname {
+		indexServer = dockerV1Hostname
+	}
+
+	return indexServer
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -76,7 +77,7 @@ func NewRegAuthContext() RegAuthContext {
 func (sc *RegAuthContext) PrepareAuth(indexServer string) error {
 	inputURL := "https://" + indexServer + "/v2/"
 
-	req, res, err := sc.SendRequestWithToken(inputURL, "GET")
+	req, res, err := sc.SendRequestWithToken(inputURL, "GET", nil)
 	if err != nil {
 		return fmt.Errorf("failed to send request to %s: %v", inputURL, err)
 	}
@@ -158,7 +159,7 @@ func (sc *RegAuthContext) getAuthToken(inputURL string) error {
 
 	sc.AuthTokens[sc.ReqHost] = tokenStruct.Token
 
-	if _, _, err := sc.SendRequestWithToken(inputURL, "GET"); err != nil {
+	if _, _, err := sc.SendRequestWithToken(inputURL, "GET", nil); err != nil {
 		return fmt.Errorf("failed to send request to %s: %v", inputURL, err)
 	}
 
@@ -170,7 +171,7 @@ func (sc *RegAuthContext) getAuthToken(inputURL string) error {
 //
 // $ curl -H "Authorization: Bearer TOKEN_STRING" https://index.docker.io/v2/library/busybox/manifests/latest
 //
-func (sc *RegAuthContext) SendRequestWithToken(inputURL, method string) (*http.Request, *http.Response, error) {
+func (sc *RegAuthContext) SendRequestWithToken(inputURL, method string, body io.Reader) (*http.Request, *http.Response, error) {
 	setBearerHeader := false
 
 	req, err := http.NewRequest(method, inputURL, nil)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	distp "github.com/kinvolk/ocicert/pkg/distp"
 )
 
 var (
@@ -184,6 +186,8 @@ func (sc *RegAuthContext) SendRequestWithToken(inputURL, method string, body io.
 		req.Header.Set("Authorization", "Bearer "+authToken)
 		setBearerHeader = true
 	}
+
+	req.Header.Set(distp.DistAPIVersionKey, "registry/2.0")
 
 	res, err := sc.Hclient.Do(req)
 	if err != nil {

--- a/pkg/distp/distp.go
+++ b/pkg/distp/distp.go
@@ -1,0 +1,22 @@
+// Copyright © 2018 ocicert authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distp
+
+const (
+	DistAPIVersionKey   string = "Docker-Distribution-API-Version"
+	DistAPIVersionValue string = "registry/2.0"
+
+	UploadUuidKey string = "Docker-Upload-Uuid"
+)

--- a/pkg/image/util.go
+++ b/pkg/image/util.go
@@ -13,33 +13,3 @@
 // limitations under the License.
 
 package image
-
-import (
-	"strings"
-)
-
-const (
-	DefaultIndexURLPlain = "registry-1.docker.io"
-	DefaultIndexURLAuth  = "index.docker.io"
-	DefaultRepoPrefix    = "library/"
-)
-
-// GetIndexName returns the index server from a registry URL.
-func GetIndexName(regURL string) string {
-	index, _ := SplitReposName(regURL)
-	return index
-}
-
-// SplitReposName breaks a repo name into an index name and remote name.
-func SplitReposName(name string) (indexName, remoteName string) {
-	i := strings.IndexRune(name, '/')
-	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
-		indexName, remoteName = DefaultIndexURLPlain, name
-	} else {
-		indexName, remoteName = name[:i], name[i+1:]
-	}
-	if indexName == DefaultIndexURLPlain && !strings.ContainsRune(remoteName, '/') {
-		remoteName = DefaultRepoPrefix + remoteName
-	}
-	return
-}


### PR DESCRIPTION
A set of refactoring and minor fixes, which will be needed by other distribution tests as a baseline.

* use a consistent name for registry URL
* move repo-related functions to pkg/auth
* split out response parts into GetResponse
* set and get Docker-* HTTP headers
* allow SendRequestAuth to take a body parameter
